### PR TITLE
Added more user friendly database login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ fabric.properties
 
 # End of https://www.toptal.com/developers/gitignore/api/intellij
 
+# Database login configuration file
+db_login.properties
+

--- a/src/main/java/org/grupp2/sdpproject/GUI/LoginScene.java
+++ b/src/main/java/org/grupp2/sdpproject/GUI/LoginScene.java
@@ -4,10 +4,8 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
-import javafx.scene.control.Alert;
-import javafx.scene.control.Alert.AlertType;
+import org.grupp2.sdpproject.Utils.DatabaseLoginManager;
 import org.grupp2.sdpproject.Utils.HibernateUtil;
-import org.grupp2.sdpproject.GUI.SceneController;
 
 public class LoginScene {
 
@@ -28,18 +26,23 @@ public class LoginScene {
 
         if (username.isEmpty() || password.isEmpty() || ip.isEmpty() || port.isEmpty()) {
             messageLabel.setText("Fyll i alla fält");
-            messageLabel.setStyle("-fx-text-fill: red;");
         }
         else {
-            //toDO måste ha alla entitys mappade först
-            //boolean success = HibernateUtil.initializeDatabase(username, password, ip, port);
-            boolean success = true;
+            // TODO: När alla entities är mappade ska den kommenterade koden tas med igen
+            boolean success = true; //HibernateUtil.initializeDatabase(username, password, ip, port);
             if (success) {
-                sceneController.switchScene("main menu");
+                try {
+                    DatabaseLoginManager.DatabaseLogin config = new DatabaseLoginManager.DatabaseLogin(username, password, ip, port);
+                    DatabaseLoginManager.writeConfigToFile(config);
+
+                    sceneController.switchScene("main menu");
+
+                } catch (Exception e) {
+                    messageLabel.setText("Kunde inte spara inloggningsuppgifter");
+                }
             }
             else {
                 messageLabel.setText("Inloggning misslyckades. Kontrollera dina uppgifter");
-                messageLabel.setStyle("-fx-text-fill: red;");
             }
         }
     }

--- a/src/main/java/org/grupp2/sdpproject/GUI/SceneController.java
+++ b/src/main/java/org/grupp2/sdpproject/GUI/SceneController.java
@@ -4,6 +4,8 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 import org.grupp2.sdpproject.Main;
+import org.grupp2.sdpproject.Utils.DatabaseLoginManager;
+import org.grupp2.sdpproject.Utils.HibernateUtil;
 
 public class SceneController {
 
@@ -27,7 +29,30 @@ public class SceneController {
 
     public void startApplication(Stage primaryStage) {
         this.primaryStage = primaryStage;
-        setScene(loginScene);
+        boolean shouldShowLogin = true;
+        if (DatabaseLoginManager.configFileExists()) {
+            try {
+                DatabaseLoginManager.DatabaseLogin config = DatabaseLoginManager.readConfigFromFile();
+
+                boolean success = HibernateUtil.initializeDatabase(
+                        config.username(),
+                        config.password(),
+                        config.ip(),
+                        config.port()
+                );
+
+                if (success) {
+                    setScene(mainMenuScene);
+                    shouldShowLogin = false;
+                }
+
+            } catch (Exception e) {
+                System.err.println("Kunde inte läsa från fil eller ansluta till databas: " + e.getMessage());
+            }
+        }
+        if (shouldShowLogin) {
+            setScene(loginScene);
+        }
     }
 
     public void switchScene(String sceneName) {

--- a/src/main/java/org/grupp2/sdpproject/Utils/DatabaseLoginManager.java
+++ b/src/main/java/org/grupp2/sdpproject/Utils/DatabaseLoginManager.java
@@ -1,0 +1,47 @@
+package org.grupp2.sdpproject.Utils;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+public class DatabaseLoginManager {
+
+    private static final String CONFIG_FILE_NAME = "db_login.properties";
+
+    public record DatabaseLogin(String username, String password, String ip, String port) {}
+
+    public static boolean configFileExists() {
+        return Files.exists(Path.of(CONFIG_FILE_NAME));
+    }
+
+    public static DatabaseLogin readConfigFromFile() throws IOException {
+        Properties props = new Properties();
+        try (FileInputStream fis = new FileInputStream(CONFIG_FILE_NAME)) {
+            props.load(fis);
+        }
+
+        String username = props.getProperty("db.username");
+        String password = props.getProperty("db.password");
+        String ip       = props.getProperty("db.ip");
+        String port     = props.getProperty("db.port");
+
+        if (username == null || password == null || ip == null || port == null) {
+            throw new IOException("Konfigfilen saknar nödvändiga fält.");
+        }
+
+        return new DatabaseLogin(username, password, ip, port);
+    }
+
+    public static void writeConfigToFile(DatabaseLogin config) throws IOException {
+        Properties props = new Properties();
+        props.setProperty("db.username", config.username());
+        props.setProperty("db.password", config.password());
+        props.setProperty("db.ip",       config.ip());
+        props.setProperty("db.port",     config.port());
+
+        try (FileOutputStream fos = new FileOutputStream(CONFIG_FILE_NAME)) {
+            props.store(fos, "Database configuration");
+        }
+    }
+}

--- a/src/main/resources/org/grupp2/sdpproject/login-scene.fxml
+++ b/src/main/resources/org/grupp2/sdpproject/login-scene.fxml
@@ -7,15 +7,16 @@
    <children>
       <VBox alignment="TOP_CENTER" prefHeight="424.0" prefWidth="600.0" styleClass="vbox">
          <children>
-            <Label text="Skriv in inloggningsuppgifter till en MySQL databas." />
+            <Label text="Skriv in inloggningsuppgifter till din MySQL databas." />
+            <Label text="Uppgifterna kommer sparas till fil och användas vid nästa start av programmet." />
             <TextField maxWidth="200.0" promptText="Användarnamn" fx:id="usernameField"/>
             <TextField maxWidth="200.0" promptText="Lösenord" fx:id="passwordField"/>
             <TextField maxWidth="200.0" promptText="IP-adress" text="localhost" fx:id="ipField"/>
             <TextField maxWidth="200.0" promptText="Port" text="3306" fx:id="portField"/>
-            <Label fx:id="messageLabel" text=""/>
+            <Label fx:id="messageLabel" styleClass="message-label"/>
             <HBox alignment="TOP_CENTER" prefHeight="23.0" prefWidth="580.0" styleClass="hbox">
                <children>
-                  <Button maxWidth="90.0" mnemonicParsing="false" text="Logga in" onAction="#handleLogin"/>
+                  <Button maxWidth="90.0" mnemonicParsing="false" text="Spara" onAction="#handleLogin"/>
                </children>
             </HBox>
          </children>

--- a/src/main/resources/org/grupp2/sdpproject/style.css
+++ b/src/main/resources/org/grupp2/sdpproject/style.css
@@ -33,6 +33,10 @@
     -fx-background-color: #004c8a;
 }
 .label {
-    -fx-padding: 10;
+    -fx-padding: 5;
     -fx-wrap-text: true;
+}
+.message-label {
+    -fx-text-fill: red;
+    -fx-font-weight: bold;
 }


### PR DESCRIPTION
We now check if there is a saved login in SceneController. 
If there is not, we open the LoginScene as normal and then save those login details to db_login.properties.
If we already have a saved login, we skip the LoginScene and go directly to the MainMenuScene.

If the login fails for whatever reason, we give the user a new chance to enter correct login details.